### PR TITLE
Brief update to Android 5.0 incompatibility

### DIFF
--- a/input/senate-submissions/unneeded-incompatibility-with-android-5-0.md
+++ b/input/senate-submissions/unneeded-incompatibility-with-android-5-0.md
@@ -2,7 +2,7 @@ Title: Unneeded incompatibility with Android 5.0
 Status: Work in Progress
 ---
 
-ndroid 5.0 Lollipop was launched by Google back in late 2014 preceded by 5.1 Lollipop in early 2015. As of April 2020 both run on 2.64% of Australia’s Android Devices which make 55% of the wider Market. (Source) The COVIDSafe app has found to have an unneeded compatibility with those devices as it’s minimum version supported is 6.0.
+Android 5.0 Lollipop was launched by Google back in late 2014 preceded by 5.1 Lollipop in early 2015. As of April 2020 both run on 2.64% of Australia’s Android Devices which make 55% of the wider Market. (Source) The COVIDSafe app has found to have an unneeded compatibility with those devices as it’s minimum version supported is 6.0.
 
 
 
@@ -12,23 +12,15 @@ Android 5.0 introduced the functionality of Bluetooth Low Energy Broadcasts, whi
 
 The other thing is that the libraries (Sets of prewritten code) that are available to the public of which the COVIDSafe app is dependent upon are compatible with Android 5.0.
 
-
-Library
-Compatibility with Android 5.0
-ProgressButton by Razir
-✅
-Lottie-android by Airbnb
-✅
-OkHttp by Square
-✅
-Okio by Square
-✅
-EasyPermissions by Google
-✅
-Retrofit by Square
-✅
-RxAndroid
-✅
+Library | Compatibility with Android 5.0
+--- | ---
+ProgressButton by Razir | ✅
+Lottie-android by Airbnb | ✅
+OkHttp by Square | ✅
+Okio by Square | ✅
+EasyPermissions by Google | ✅
+Retrofit by Square | ✅
+RxAndroid | ✅
 
 One item that no one in the community can figure out is the closed source (meaning private) library called “com.atlassian.mobilekit” of which the COVIDSafe app is dependent upon. There is speculation that since the COVIDSafe app is dependent on this library, that it is forced to make the minimum version 6.0. 
 Atlassian, the creators of this library, could potentially make a derivative that works on 5.0 & 5.1 devices.


### PR DESCRIPTION
Just did a small fix with adding a table in for compatibility of libraries used in Covidsafe.

I'll make another pull request a bit later with some of the other formatting transferred over from the Google Doc as well as the bar graph image showing the Android Marketshare in Australia.